### PR TITLE
Update test_no_event_for_trigger()

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -91,7 +91,8 @@ def test_no_event_for_trigger():
     obs = Observable()
     nose.assert_equals(obs._events, {})
 
-    nose.assert_raises(Observable.EventNotFound, obs.trigger, "no_existing_event")
+    nose.assert_false(obs.trigger("no_existing_event"))
+    nose.assert_raises(Observable.EventNotFound, obs.off, "no_existing_event")
 
 
 def test_off():


### PR DESCRIPTION
With cbc4520b4560c125a32156a3970ee651f46ab775 this test fails as `obs.trigger` no longer raises `Observable.EventNotFound`, only returning `False`. However `obs.off` does raise it so testing both.
