### PR TITLE
Do not mark wheel as universal, closes #14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ class UploadCommand(Command):
         except OSError:
             pass
 
-        self.status("Building Source and Wheel (universal) distribution…")
-        os.system("{0} setup.py sdist bdist_wheel --universal".format(sys.executable))
+        self.status("Building Source and Wheel distribution…")
+        os.system("{0} setup.py sdist bdist_wheel".format(sys.executable))
 
         self.status("Uploading the package to PyPi via Twine…")
         os.system("twine upload dist/*")


### PR DESCRIPTION
Here I removed ``--universal`` flag from wheel building command because ``observable`` is Python 3 only since 1.0.1.

This pull request closes #14.