### PR TITLE
Makes typing of observable usable from other projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
     author_email="tuxtimo@gmail.com",
     url="https://github.com/timofurrer/observable",
     packages=find_packages(),
+    package_data=dict(observable=['py.typed']),
     install_requires=required,
     license="MIT",
     classifiers=(

--- a/setup.py
+++ b/setup.py
@@ -93,4 +93,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ),
     cmdclass={"upload": UploadCommand},
+    zip_safe=False,  # Because mypy cannot analyse a zip
 )


### PR DESCRIPTION
Hello, 

This is a simple PR to make the package usable by mypy from another project.
- Special file "py.typed" to mark the package as importable by mypy.
- Ensure setup.py do not generate a zip file as mypy would not be able to process it.


Cheers,
Axel